### PR TITLE
refactor: rewrite csrf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - '4'
   - '6'
+  - '7'
 install:
   - npm i npminstall && npminstall
 script:

--- a/README.md
+++ b/README.md
@@ -211,10 +211,12 @@ there are some options that you can customize:
 exports.security = {
   csrf: {
     useSession: false,          // if useSession set to true, the secret will keep in session instead of cookie
+    ignoreJSON: false,          // skip check JSON requests if ignoreJSON set to true
     cookieName: 'csrfToken',    // csrf token's cookie name
     sessionName: 'csrfToken',   // csrf token's session name
     headerName: 'x-csrf-token', // request csrf token's name in header
     bodyName: '_csrf',          // request csrf token's name in body
+    queryName: '_csrf',         // request csrf token's name in query
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -160,16 +160,16 @@ exports.security = {
 
 ## Interface restriction
 
-### csrf
+### CSRF
 
 __usage__
 
-* `ctx.csrf` getter for csrf token
+* `ctx.csrf` getter for CSRF token
 
 Generally used when send POST form request. When page rendering, put `ctx.csrf` into form hidden field or query string.(`_csrf` is the key).
 When submitting the form, please submit with the `_csrf` token parameter.
 
-#### Using csrf when upload by formData
+#### Using CSRF when upload by formData
 
 browser:
 
@@ -181,11 +181,11 @@ browser:
 </form>
 ```
 
-#### Using csrf when request by AJAX
+#### Using CSRF when request by AJAX
 
-csrf token will also set to cookie by default, and you can send token through header:
+CSRF token will also set to cookie by default, and you can send token through header:
 
-In jquery,
+In jQuery:
 
 ```js
 var csrftoken = Cookies.get('csrftoken');

--- a/README.md
+++ b/README.md
@@ -181,6 +181,44 @@ browser:
 </form>
 ```
 
+#### Using csrf when request by AJAX
+
+csrf token will also set to cookie by default, and you can send token through header:
+
+In jquery,
+
+```js
+var csrftoken = Cookies.get('csrftoken');
+
+function csrfSafeMethod(method) {
+  // these HTTP methods do not require CSRF protection
+  return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+$.ajaxSetup({
+  beforeSend: function(xhr, settings) {
+    if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+      xhr.setRequestHeader('x-csrf-token', csrftoken);
+    }
+  },
+});
+```
+
+#### options
+
+there are some options that you can customize:
+
+```js
+exports.security = {
+  csrf: {
+    useSession: false,          // if useSession set to true, the secret will keep in session instead of cookie
+    cookieName: 'csrfToken',    // csrf token's cookie name
+    sessionName: 'csrfToken',   // csrf token's session name
+    headerName: 'x-csrf-token', // request csrf token's name in header
+    bodyName: '_csrf',          // request csrf token's name in body
+  },
+}
+```
+
 ### safe redirect
 
 * `ctx.redirect(url)` If url is not in the configuration of the white list, the redirect will be prohibited

--- a/app.js
+++ b/app.js
@@ -3,10 +3,8 @@
 const safeRedirect = require('./lib/safe_redirect');
 
 module.exports = app => {
-  app.config.coreMiddleware.push('security');
+  app.config.coreMiddleware.push('securities');
 
   // patch response.redirect
   safeRedirect(app);
-
-  require('./lib/csrf/default')(app);
 };

--- a/app/middleware/securities.js
+++ b/app/middleware/securities.js
@@ -5,7 +5,8 @@ const path = require('path');
 const assert = require('assert');
 const pathToReg = require('../../lib/utils').pathToReg;
 
-module.exports = (options, app) => {
+module.exports = (_, app) => {
+  const options = app.config.security;
   const middlewares = [];
   const defaultMiddleware = (options.defaultMiddleware || '').split(',');
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-    - nodejs_version: '4'
     - nodejs_version: '6'
+    - nodejs_version: '7'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -29,6 +29,7 @@ module.exports = () => {
       sessionName: 'csrfToken',
       headerName: 'x-csrf-token',
       bodyName: '_csrf',
+      queryName: '_csrf',
     },
 
     xframe: {

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -24,6 +24,7 @@ module.exports = () => {
 
     csrf: {
       enable: true,
+      useSession: false,
       cookieName: 'csrfToken',
       sessionName: 'csrfToken',
       headerName: 'x-csrf-token',

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -25,6 +25,7 @@ module.exports = () => {
     csrf: {
       enable: true,
       useSession: false,
+      ignoreJSON: false,
       cookieName: 'csrfToken',
       sessionName: 'csrfToken',
       headerName: 'x-csrf-token',

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -24,6 +24,10 @@ module.exports = () => {
 
     csrf: {
       enable: true,
+      cookieName: 'csrfToken',
+      sessionName: 'csrfToken',
+      headerName: 'x-csrf-token',
+      bodyName: '_csrf',
     },
 
     xframe: {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = require('./app/middleware/security');
+module.exports = require('./app/middleware/securities');
 module.exports.csp = require('./lib/middlewares/csp');
 module.exports.csrf = require('./lib/middlewares/csrf');
 module.exports.methodNoAllow = require('./lib/middlewares/methodnoallow');

--- a/lib/csrf/default.js
+++ b/lib/csrf/default.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const csrf = require('koa-csrf');
-
-module.exports = app => {
-  csrf(app);
-};

--- a/lib/middlewares/csrf.js
+++ b/lib/middlewares/csrf.js
@@ -5,11 +5,15 @@ const utils = require('../utils');
 
 module.exports = options => {
   return function* csrf(next) {
-    // ignore requests: get, head, options
+    // set csrf token if not present
+    if (!this.csrfSecret) this.setCsrfSecret();
+
+    // ignore requests: get, head, options and trace
     const method = this.method;
     if (method === 'GET' ||
       method === 'HEAD' ||
-      method === 'OPTIONS') {
+      method === 'OPTIONS' ||
+      method === 'TRACE') {
       return yield next;
     }
 
@@ -17,29 +21,13 @@ module.exports = options => {
       return yield next;
     }
 
-    const body = this.request.body || {};
-    debug('%s %s, got %j', this.method, this.url, body);
-
-    try {
-      this.assertCSRF(body);
-    } catch (err) {
-      debug('%s %s, error: %s', this.method, this.url, err.message);
-      if (err.status !== 403) this.throw(err);
-
-      this.status = 403;
-      const message = err.message || 'invalid csrf token';
-      if (message === 'token is missing' && this.app.config.env === 'local') {
-        const err = new Error('csrf token is missing when post');
-        this.logger.error(err);
-      } else {
-        this.logger.warn(err);
-      }
-      this.body = this.accepts('html', 'text', 'json') === 'json'
-        ? { message }
-        : message;
-      return;
+    if (options.ignoreJSON && this.is('json')) {
+      return yield next;
     }
 
+    const body = this.request.body || {};
+    debug('%s %s, got %j', this.method, this.url, body);
+    this.assertCsrf();
     yield next;
   };
 };

--- a/lib/middlewares/csrf.js
+++ b/lib/middlewares/csrf.js
@@ -5,8 +5,8 @@ const utils = require('../utils');
 
 module.exports = options => {
   return function* csrf(next) {
-    // set csrf token if not present
-    if (!this.csrfSecret) this.setCsrfSecret();
+    // ensure csrf token exists
+    this.ensureCsrfSecret();
 
     // ignore requests: get, head, options and trace
     const method = this.method;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "autod": "autod"
   },
   "ci": {
-    "version": "4, 6"
+    "version": "6, 7"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "plugin"
   ],
   "dependencies": {
+    "csrf": "^3.0.4",
     "debug": "^2.2.0",
     "delegates": "^1.0.0",
     "escape-html": "^1.0.3",
@@ -31,7 +32,7 @@
     "autod": "^2.7.1",
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.1",
-    "egg": "~0.1.0",
+    "egg": "~0.7.0",
     "egg-bin": "1",
     "egg-ci": "1",
     "egg-mock": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "autod": "^2.7.1",
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.1",
-    "egg": "~0.7.0",
+    "egg": "~0.8.0",
     "egg-bin": "1",
     "egg-ci": "1",
     "egg-mock": "^0.0.4",

--- a/test/csrf.test.js
+++ b/test/csrf.test.js
@@ -1,120 +1,221 @@
 'use strict';
 
-const should = require('should');
+const assert = require('assert');
 const request = require('supertest');
 const mm = require('egg-mock');
-const pedding = require('pedding');
 
 describe('test/csrf.test.js', function() {
-  describe('type: default', function() {
-    before(function(done) {
-      this.app = mm.app({
-        baseDir: 'apps/csrf',
-        plugin: 'security',
+  before(function(done) {
+    this.app = mm.app({
+      baseDir: 'apps/csrf',
+      plugin: 'security',
+    });
+    this.app.ready(done);
+  });
+
+  afterEach(mm.restore);
+
+  it('should update form with csrf token', function* () {
+    const agent = request.agent(this.app.callback());
+
+    let res = yield agent
+      .get('/')
+      .set('accept', 'text/html')
+      .expect(200);
+    assert(res.text);
+    const csrfToken = res.text;
+    res = yield agent
+      .post('/update')
+      .set('content-type', 'application/x-www-form-urlencoded')
+      .send({
+        _csrf: csrfToken,
+        title: `ok token: ${csrfToken}`,
+      })
+      .expect(200)
+      .expect({
+        _csrf: csrfToken,
+        title: `ok token: ${csrfToken}`,
       });
-      this.app.ready(done);
-    });
+  });
 
-    afterEach(mm.restore);
+  it('should update form with csrf token using session', function* () {
+    mm(this.app.config.security.csrf, 'useSession', true);
+    const agent = request.agent(this.app.callback());
 
-    it('should update form with csrf token', function(done) {
-      const agent = request.agent(this.app.callback());
+    let res = yield agent
+      .get('/')
+      .set('accept', 'text/html')
+      .expect(200);
+    assert(res.text);
+    const csrfToken = res.text;
+    res = yield agent
+      .post('/update')
+      .set('content-type', 'application/x-www-form-urlencoded')
+      .send({
+        _csrf: csrfToken,
+        title: `ok token: ${csrfToken}`,
+      })
+      .expect(200)
+      .expect({
+        _csrf: csrfToken,
+        title: `ok token: ${csrfToken}`,
+      });
+  });
 
-      agent
-        .get('/')
-        .set('accept', 'text/html')
-        .expect(200, function(err, res) {
-          should.not.exist(err);
-          should.exist(res.text);
+  it('should update json with csrf token using session', function* () {
+    mm(this.app.config.security.csrf, 'useSession', true);
+    const agent = request.agent(this.app.callback());
 
-          const csrfToken = res.text;
+    let res = yield agent
+      .get('/')
+      .set('accept', 'text/html')
+      .expect(200);
+    assert(res.text);
+    const csrfToken = res.text;
+    res = yield agent
+      .post('/update')
+      .send({
+        _csrf: csrfToken,
+        title: `ok token: ${csrfToken}`,
+      })
+      .expect(200)
+      .expect({
+        _csrf: csrfToken,
+        title: `ok token: ${csrfToken}`,
+      });
+  });
 
-          agent
-            .post('/update')
-            .send({
-              _csrf: csrfToken,
-              title: '哈哈, ok token:' + csrfToken,
-            })
-            .expect(200, function(err, res) {
-              should.not.exist(err);
-              res.body.should.eql({
-                _csrf: csrfToken,
-                title: '哈哈, ok token:' + csrfToken,
-              });
-              done();
-            });
-        });
-    });
+  it('should update form with csrf token from cookie and set to header', function* () {
+    const agent = request.agent(this.app.callback());
 
-    it('should return 403 update form without csrf token', function(done) {
-      const agent = request.agent(this.app.callback());
+    let res = yield agent
+      .get('/')
+      .set('accept', 'text/html')
+      .expect(200);
+    assert(res.text);
+    const cookie = res.headers['set-cookie'].join(';');
+    const csrfToken = cookie.match(/csrfToken=(.*?);/)[1];
+    res = yield agent
+      .post('/update')
+      .set('x-csrf-token', csrfToken)
+      .send({
+        title: `ok token: ${csrfToken}`,
+      })
+      .expect(200)
+      .expect({
+        title: `ok token: ${csrfToken}`,
+      });
+  });
 
-      agent
-        .get('/')
-        .set('accept', 'text/html')
-        .expect(200, function(err, res) {
-          should.not.exist(err);
-          should.exist(res.text);
-          agent
-            .post('/update')
-            .set('accept', 'text/html')
-            .expect(403, function(err, res) {
-              should.not.exist(err);
-              res.text.should.equal('invalid csrf token');
-              done();
-            });
-        });
-    });
+  it('should update form with csrf token from cookie and set to body', function* () {
+    const agent = request.agent(this.app.callback());
 
-    it('should support ignore paths', function(done) {
-      done = pedding(3, done);
+    let res = yield agent
+      .get('/')
+      .set('accept', 'text/html')
+      .expect(200);
+    assert(res.text);
+    const cookie = res.headers['set-cookie'].join(';');
+    const csrfToken = cookie.match(/csrfToken=(.*?);/)[1];
+    res = yield agent
+      .post('/update')
+      .send({
+        _csrf: csrfToken,
+        title: `ok token: ${csrfToken}`,
+      })
+      .expect(200)
+      .expect({
+        _csrf: csrfToken,
+        title: `ok token: ${csrfToken}`,
+      });
+  });
 
-      request(this.app.callback())
-        .post('/update')
-        .send({
-          foo: 'bar',
-        })
-        .expect(403, done);
+  it('should ignore json if ignoreJSON = true', function* () {
+    mm(this.app.config.security.csrf, 'ignoreJSON', true);
+    yield request(this.app.callback())
+      .post('/update')
+      .send({
+        title: 'without token ok',
+      })
+      .expect(200)
+      .expect({
+        title: 'without token ok',
+      });
+  });
 
-      request(this.app.callback())
-        .post('/api/update')
-        .send({
-          foo: 'bar',
-        })
-        .expect(404, done);
+  it('should not ignore form if ignoreJSON = true', function* () {
+    mm(this.app.config.security.csrf, 'ignoreJSON', true);
+    yield request(this.app.callback())
+      .post('/update')
+      .set('content-type', 'application/x-www-form-urlencoded')
+      .send({
+        title: 'without token ok',
+      })
+      .expect(403);
+  });
 
-      request(this.app.callback())
-        .post('/api/users/posts')
-        .send({
-          foo: 'bar',
-        })
-        .expect(404, done);
-    });
+  it('should return 403 update form without csrf token', function* () {
+    const agent = request.agent(this.app.callback());
 
-    it('should got next when is GET/HEAD/OPTIONS method', function(done) {
-      done = pedding(3, done);
+    yield agent
+      .get('/')
+      .set('accept', 'text/html')
+      .expect(200);
 
-      request(this.app.callback())
-        .get('/update.json;')
-        .expect(404, done);
-
-      request(this.app.callback())
-        .head('/update.tile;')
-        .expect(404, done);
-
-      request(this.app.callback())
-        .options('/update.ajax;')
-        .expect(404, done);
-    });
-
-    it('should throw 500 if this.assertCSRF() throw not 403 error', function(done) {
-      mm.syncError(this.app.context, 'assertCSRF', 'mock assertCSRF error');
-
-      request(this.app.callback())
-        .post('/foo')
-        .expect(500, done);
-    });
+    yield agent
+      .post('/update')
+      .set('accept', 'text/html')
+      .expect(403)
+      .expect(/invalid csrf token/);
   });
 
 
+  it('should support ignore paths', function* () {
+    yield request(this.app.callback())
+      .post('/update')
+      .send({
+        foo: 'bar',
+      })
+      .expect(403);
+
+    yield request(this.app.callback())
+      .post('/api/update')
+      .send({
+        foo: 'bar',
+      })
+      .expect(404);
+
+    yield request(this.app.callback())
+      .post('/api/users/posts')
+      .send({
+        foo: 'bar',
+      })
+      .expect(404);
+  });
+
+  it('should got next when is GET/HEAD/OPTIONS/TRACE method', function* () {
+    yield request(this.app.callback())
+      .get('/update.json;')
+      .expect(404);
+
+    yield request(this.app.callback())
+      .head('/update.tile;')
+      .expect(404);
+
+    yield request(this.app.callback())
+      .options('/update.ajax;')
+      .expect(404);
+
+    yield request(this.app.callback())
+      .trace('/update.ajax;')
+      .expect(404);
+  });
+
+  it('should throw 500 if this.assertCsrf() throw not 403 error', function* () {
+    mm.syncError(this.app.context, 'assertCsrf', 'mock assertCsrf error');
+
+    yield request(this.app.callback())
+      .post('/foo')
+      .expect(500);
+  });
 });

--- a/test/fixtures/apps/csrf/app/controller/home.js
+++ b/test/fixtures/apps/csrf/app/controller/home.js
@@ -4,6 +4,11 @@ exports.index = function* () {
   this.body = this.csrf;
 };
 
+exports.rotate = function* () {
+  this.ensureCsrfSecret(true);
+  this.body = this.csrf;
+};
+
 exports.update = function* () {
   this.session.body = this.request.body;
   this.body = this.request.body;

--- a/test/fixtures/apps/csrf/app/router.js
+++ b/test/fixtures/apps/csrf/app/router.js
@@ -2,5 +2,6 @@
 
 module.exports = function(app) {
   app.get('/', app.controller.home.index);
+  app.get('/rotate', app.controller.home.rotate);
   app.post('/update', app.controller.home.update);
 };

--- a/test/fixtures/apps/utils-check-if-pass/config/config.js
+++ b/test/fixtures/apps/utils-check-if-pass/config/config.js
@@ -3,7 +3,6 @@
 exports.security = {
   defaultMiddleware: 'csp',
   match: /\/(?:match|ignore)/,
-  ignore: /\/(?:ignore|luckydrq)/,
   csp: {
     enable: true
   }

--- a/test/fixtures/apps/utils-check-if-pass2/config/config.js
+++ b/test/fixtures/apps/utils-check-if-pass2/config/config.js
@@ -3,10 +3,8 @@
 exports.security = {
   defaultMiddleware: 'csp',
   match: /\/match/,
-  ignore: /\/ignore/,
   csp: {
     match: /\/(?:mymatch|myignore)/,
-    ignore: /\/(?:myignore|mytrueignore)/,
     enable: true
   }
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -97,7 +97,7 @@ describe('test/utils.test.js', function() {
 
     afterEach(mm.restore);
 
-    it('should use global match', function(done) {
+    it('should use match', function(done) {
       request(this.app.callback())
         .get('/match')
         .expect(200, function(err, res) {


### PR DESCRIPTION
重构 csrf。closes https://github.com/eggjs/egg/issues/260

1. 支持 cookie / session 存放 csrf secret。
2. 支持 body  / header 发送 csrf token。
3. 支持对 json 类型的请求不做 csrf 校验。

- session 存为 CSRF Tokens 模式。
- cookie 存为 Double Submit Cookies 模式。