### PR TITLE
domainWhiteList supports wildcard character(*)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,10 @@ exports.isSafeDomain = function isSafeDomain(domain, domain_white_list) {
   // add prefix `.`, because all domains in white list are start with `.`
   const hostname = '.' + domain;
   return domain_white_list.some(function(rule) {
+    if (/\*/g.test(rule)) {
+      const re = new RegExp(rule.replace(/\*/, '[0-9a-zA-Z]+'));
+      return re.test(hostname);
+    }
     return hostname.endsWith(rule);
   });
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -47,6 +47,13 @@ describe('test/utils.test.js', function() {
       utils.isSafeDomain('okokok----.domain.com', domainWhiteList).should.equal(true);
     });
 
+    it('should return true when wildcard character inuse', function() {
+      const domainWhiteList = [ '*.domain.com' ];
+      utils.isSafeDomain('api.domain.com', domainWhiteList).should.equal(true);
+      utils.isSafeDomain('products.domain.com', domainWhiteList).should.equal(true);
+      utils.isSafeDomain('foo.domain.com', domainWhiteList).should.equal(true);
+    });
+
     it('should return false', function() {
       utils.isSafeDomain('aaa-domain.com', domainWhiteList).should.equal(false);
       utils.isSafeDomain(' domain.com', domainWhiteList).should.equal(false);


### PR DESCRIPTION
Add wildcard character(`*`) rule to `domainWhiteList`.

---

The `config.security.domainWhileList` can node like blow:
``` javascript
config.security = {
    domainWhiteList: [
        'http://192.168.1.100:8080', // normal string rule
        '192.168.1.*', // will transfer to RegExp rule
        '192.168.2.100:*', // will transfer to RegExp rule
        '*.somesite.com' // will transfer to RegExp rule
    ]
};
```

It helps greatly with client-server-separation development when using egg. 