### PR TITLE
fix: disable nosniff on redirect status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - '6'
   - '8'
+  - '10'
 install:
   - npm i npminstall && npminstall
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
     - nodejs_version: '6'
     - nodejs_version: '8'
+    - nodejs_version: '10'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/lib/middlewares/nosniff.js
+++ b/lib/middlewares/nosniff.js
@@ -1,10 +1,14 @@
 'use strict';
 
+const statuses = require('statuses');
 const utils = require('../utils');
 
 module.exports = options => {
   return function* nosniff(next) {
     yield next;
+
+    // ignore redirect response
+    if (statuses.redirect[this.status]) return;
 
     const opts = utils.merge(options, this.securityOptions.nosniff);
     if (utils.checkIfIgnore(opts, this)) return;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "methods": "^1.1.2",
     "platform": "^1.3.4",
     "rndm": "^1.2.0",
+    "statuses": "^1.5.0",
     "type-is": "^1.6.15",
     "xss": "^0.3.3"
   },
@@ -59,7 +60,10 @@
     "autod": "autod"
   },
   "ci": {
-    "version": "6, 8"
+    "version": "6, 8, 10"
+  },
+  "publishConfig": {
+    "tag": "latest-1"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/apps/nosniff/app/router.js
+++ b/test/fixtures/apps/nosniff/app/router.js
@@ -9,4 +9,18 @@ module.exports = function(app) {
     this.securityOptions.nosniff = { enable: false };
     this.body = '123';
   });
+
+  app.get('/redirect', function *(){
+    this.redirect('/');
+  });
+
+  app.get('/redirect301', function *(){
+    this.status = 301;
+    this.redirect('/');
+  });
+
+  app.get('/redirect307', function *(){
+    this.status = 307;
+    this.redirect('/');
+  });
 };

--- a/test/nosniff.test.js
+++ b/test/nosniff.test.js
@@ -33,5 +33,28 @@ describe('test/nosniff.test.js', function() {
         .expect(200, done);
     });
 
+    it('should disable nosniff on redirect 302', function() {
+      return this.app.httpRequest()
+        .get('/redirect')
+        .expect(res => assert(!res.headers['x-content-type-options']))
+        .expect('location', '/')
+        .expect(302);
+    });
+
+    it('should disable nosniff on redirect 301', function() {
+      return this.app.httpRequest()
+        .get('/redirect301')
+        .expect(res => assert(!res.headers['x-content-type-options']))
+        .expect('location', '/')
+        .expect(301);
+    });
+
+    it('should disable nosniff on redirect 307', function() {
+      return this.app.httpRequest()
+        .get('/redirect307')
+        .expect(res => assert(!res.headers['x-content-type-options']))
+        .expect('location', '/')
+        .expect(307);
+    });
   });
 });


### PR DESCRIPTION
pick from https://github.com/eggjs/egg-security/pull/38