### PR TITLE
fix: fix referrer-policy enum check

### DIFF
--- a/lib/middlewares/referrerPolicy.js
+++ b/lib/middlewares/referrerPolicy.js
@@ -21,7 +21,7 @@ module.exports = options => {
     const opts = utils.merge(options, ctx.securityOptions.refererPolicy);
     if (utils.checkIfIgnore(opts, ctx)) { return; }
     const policy = opts.value;
-    if (ALLOWED_POLICIES_ENUM.indexOf(policy) < 0) {
+    if (!ALLOWED_POLICIES_ENUM.includes(policy)) {
       throw new Error('"' + policy + '" is not available."');
     }
 

--- a/lib/middlewares/referrerPolicy.js
+++ b/lib/middlewares/referrerPolicy.js
@@ -21,7 +21,7 @@ module.exports = options => {
     const opts = utils.merge(options, ctx.securityOptions.refererPolicy);
     if (utils.checkIfIgnore(opts, ctx)) { return; }
     const policy = opts.value;
-    if (policy in ALLOWED_POLICIES_ENUM) {
+    if (ALLOWED_POLICIES_ENUM.indexOf(policy) < 0) {
       throw new Error('"' + policy + '" is not available."');
     }
 

--- a/test/fixtures/apps/referrer-config/app/router.js
+++ b/test/fixtures/apps/referrer-config/app/router.js
@@ -4,4 +4,12 @@ module.exports = function(app) {
   app.get('/', function *(){
     this.body = '123';
   });
+  app.get('/referrer', function *(){
+    const policy = this.query.policy;
+    this.body = '123';
+    this.securityOptions.refererPolicy = {
+      enable: true,
+      value: policy
+    }
+  });
 };

--- a/test/referrer.test.js
+++ b/test/referrer.test.js
@@ -46,5 +46,15 @@ describe('test/referrer.test.js', function() {
         .expect(500, done);
     });
 
+    // check for fix https://github.com/eggjs/egg-security/pull/50
+    it('should throw error when Referrer-Policy is set to index of item in ALLOWED_POLICIES_ENUM', function(done) {
+      const policy = 0;
+      this.app2.httpRequest()
+        .get(`/referrer?policy=${policy}`)
+        .set('accept', 'text/html')
+        .expect(new RegExp(`"${policy}" is not available.`))
+        .expect(500, done);
+    });
+
   });
 });

--- a/test/referrer.test.js
+++ b/test/referrer.test.js
@@ -37,5 +37,14 @@ describe('test/referrer.test.js', function() {
         .expect(200, done);
     });
 
+    it('should throw error when Referrer-Policy settings is invalid when configured', function(done) {
+      const policy = 'oorigin';
+      this.app2.httpRequest()
+        .get(`/referrer?policy=${policy}`)
+        .set('accept', 'text/html')
+        .expect(new RegExp(`"${policy}" is not available.`))
+        .expect(500, done);
+    });
+
   });
 });


### PR DESCRIPTION
不知道是不是理解错了，这里的`ALLOWED_POLICIES_ENUM`是用于校验设定的`referrer-policy`是否合法的，而源代码
```javascript
 if (policy in ALLOWED_POLICIES_ENUM) {
     throw new Error('"' + policy + '" is not available."');
 }
```
只有数组下标才会进入判断

比如
`'origin' in ALLOWED_POLICIES_ENUM`返回`false`
`'oorigin' in ALLOWED_POLICIES_ENUM`也返回`false`
`'0' in ALLOWED_POLICIES_ENUM`返回`true`

这就失去了判断的意义