### PR TITLE
csrf开启useSession同时也写入Cookie，客户端可以沿用原来逻辑：从cookie中读取ctoken写入到httpheader，在服务端校验session中的值。

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ exports.security = {
   csrf: {
     type: 'ctoken',             // can be ctoken or referer or all, default to ctoken
     useSession: false,          // if useSession set to true, the secret will keep in session instead of cookie
+    useSessionWithCookie: false,          // Only work if useSession is true. It will set Cookie cookieName with csrf token. csrf token compare with cookie and session.
     ignoreJSON: false,          // skip check JSON requests if ignoreJSON set to true
     cookieName: 'csrfToken',    // csrf token's cookie name
     sessionName: 'csrfToken',   // csrf token's session name

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -102,15 +102,14 @@ module.exports = {
 
     if (useSession) {
       this.session[sessionName] = secret;
-    } else {
-      const cookieOpts = {
-        domain: cookieDomain && cookieDomain(this),
-        signed: false,
-        httpOnly: false,
-        overwrite: true,
-      };
-      this.cookies.set(cookieName, secret, cookieOpts);
     }
+    const cookieOpts = {
+      domain: cookieDomain && cookieDomain(this),
+      signed: false,
+      httpOnly: false,
+      overwrite: true,
+    };
+    this.cookies.set(cookieName, secret, cookieOpts);
   },
 
   get [INPUT_TOKEN]() {

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -98,18 +98,22 @@ module.exports = {
     debug('ensure csrf secret, exists: %s, rotate; %s', this[CSRF_SECRET], rotate);
     const secret = tokens.secretSync();
     this[NEW_CSRF_SECRET] = secret;
-    const { useSession, sessionName, cookieDomain, cookieName } = this.app.config.security.csrf;
-
-    if (useSession) {
-      this.session[sessionName] = secret;
-    }
+    const { useSession, useSessionWithCookie, sessionName, cookieDomain, cookieName } = this.app.config.security.csrf;
     const cookieOpts = {
       domain: cookieDomain && cookieDomain(this),
       signed: false,
       httpOnly: false,
       overwrite: true,
     };
-    this.cookies.set(cookieName, secret, cookieOpts);
+
+    if (useSession) {
+      this.session[sessionName] = secret;
+      if (useSessionWithCookie) {
+        this.cookies.set(cookieName, secret, cookieOpts);
+      }
+    } else {
+      this.cookies.set(cookieName, secret, cookieOpts);
+    }
   },
 
   get [INPUT_TOKEN]() {

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -35,6 +35,8 @@ module.exports = () => {
 
       // These config works when using ctoken type
       useSession: false,
+      // This config only work when using useSession:true
+      useSessionWithCookie: false,
       // can be function(ctx) or String
       cookieDomain: undefined,
       cookieName: 'csrfToken',

--- a/test/csrf.test.js
+++ b/test/csrf.test.js
@@ -338,7 +338,7 @@ describe('test/csrf.test.js', () => {
     mm(this.app.config.security.csrf, 'ignoreJSON', true);
     yield this.app.httpRequest()
       .post('/update')
-      .set('content-length', '')
+      .set('content-length', '0')
       .set('content-type', 'application/json')
       .expect(200)
       .expect({});

--- a/test/csrf.test.js
+++ b/test/csrf.test.js
@@ -115,6 +115,28 @@ describe('test/csrf.test.js', () => {
       });
   });
 
+  it('should update form with csrf token using session & cookie', function* () {
+    mm(this.app.config.security.csrf, 'useSession', true);
+    const agent = request.agent(this.app.callback());
+
+    let res = yield agent
+      .get('/')
+      .set('accept', 'text/html')
+      .expect(200);
+    const setCookies = res.headers['set-cookie'];
+    const csrfCookie = setCookies.find(cookie => {
+      return cookie.indexOf('csrfToken') > -1;
+    });
+    const csrfToken = csrfCookie.split(';')[0].split('=')[1];
+    assert(csrfToken);
+    res = yield agent
+      .post('/update')
+      .set('content-type', 'application/x-www-form-urlencoded')
+      .set('x-csrf-token', csrfToken)
+      .expect(200);
+    assert(res.text === '{}');
+  });
+
   it('should update json with csrf token using session', function* () {
     mm(this.app.config.security.csrf, 'useSession', true);
     const agent = request.agent(this.app.callback());

--- a/test/csrf.test.js
+++ b/test/csrf.test.js
@@ -117,6 +117,31 @@ describe('test/csrf.test.js', () => {
 
   it('should update form with csrf token using session & cookie', function* () {
     mm(this.app.config.security.csrf, 'useSession', true);
+    mm(this.app.config.security.csrf, 'useSessionWithCookie', false);
+    const agent = request.agent(this.app.callback());
+
+    let res = yield agent
+      .get('/')
+      .set('accept', 'text/html')
+      .expect(200);
+    const setCookies = res.headers['set-cookie'];
+    const csrfCookie = setCookies.find(cookie => {
+      return cookie.indexOf('csrfToken') > -1;
+    });
+    assert(csrfCookie === undefined);
+    assert(res.text);
+    const csrfToken = res.text;
+    res = yield agent
+      .post('/update')
+      .set('content-type', 'application/x-www-form-urlencoded')
+      .set('x-csrf-token', csrfToken)
+      .expect(200);
+    assert(res.text === '{}');
+  });
+
+  it('should update form with csrf token using session & cookie', function* () {
+    mm(this.app.config.security.csrf, 'useSession', true);
+    mm(this.app.config.security.csrf, 'useSessionWithCookie', true);
     const agent = request.agent(this.app.callback());
 
     let res = yield agent


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->