### PR TITLE
feat: context 中的 `isSafeDomain()` 函数增加自定义白名单参数

### DIFF
--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -38,11 +38,14 @@ module.exports = {
   /**
    * Check whether the specific `domain` is in / matches the whiteList or not.
    * @param {string} domain The assigned domain.
+   * @param {Array<string>} customWhiteList The custom white list for domain.
    * @return {boolean} If the domain is in / matches the whiteList, return true;
    * otherwise false.
    */
-  isSafeDomain(domain) {
-    const domainWhiteList = this.app.config.security.domainWhiteList;
+  // TODO: add customWhiteList option document.
+  isSafeDomain(domain, customWhiteList) {
+    const domainWhiteList = customWhiteList && customWhiteList.length > 0 ? customWhiteList : this.app.config.security.domainWhiteList;
+    // const domainWhiteList = this.app.config.security.domainWhiteList;
     return utils.isSafeDomain(domain, domainWhiteList);
   },
 

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,0 +1,31 @@
+const { strict: assert } = require('node:assert');
+const mm = require('egg-mock');
+
+describe('test/context.test.js', () => {
+  afterEach(mm.restore);
+  describe('context.isSafeDomain', () => {
+    let app;
+    before(() => {
+      app = mm.app({
+        baseDir: 'apps/isSafeDomain-custom',
+      });
+      return app.ready();
+    });
+
+    it('should return false when domains are not safe', async () => {
+      const res = await app.httpRequest()
+        .get('/unsafe')
+        .set('accept', 'text/html')
+        .expect(200);
+      assert(res.text === 'false');
+    });
+
+    it('should return true when domains are safe', async () => {
+      const res = await app.httpRequest()
+        .get('/safe')
+        .set('accept', 'text/html')
+        .expect(200);
+      assert(res.text === 'true');
+    });
+  });
+});

--- a/test/fixtures/apps/isSafeDomain-custom/app/router.js
+++ b/test/fixtures/apps/isSafeDomain-custom/app/router.js
@@ -1,0 +1,54 @@
+module.exports = function (app) {
+  const customWhiteList = [
+    '*.foo.com',
+    '*.bar.net',
+  ];
+
+  app.get('/unsafe', async function() {
+    const unsafeDomains = [
+      // unsafe
+      'aAa-domain.com',
+      '192.1.168.0',
+      'http://www.baidu.com/zh-CN',
+      'www.alimama.com',
+      'foo.com.cn',
+      'a.foo.com.cn',
+
+      // safe
+      'pre-www.foo.com',
+      'pre-www.bar.net',
+    ];
+    let unsafeCounter = 0;
+    for (let unsafeDomain of unsafeDomains) {
+      if (!this.isSafeDomain(unsafeDomain, customWhiteList)) {
+        unsafeCounter++;
+      }
+    }
+    
+    this.body = unsafeCounter === 6 ? false : true;
+  });
+
+  app.get('/safe', async function() {
+    const safeDomains = [
+      'a.foo.com',
+      'a.b.foo.com',
+      'a.b.c.foo.com',
+      'pre-www.foo.com',
+      'test.pre-www.foo.com',
+      'a.bar.net',
+      'a.b.bar.net',
+      'a.b.c.bar.net',
+      'pre-www.bar.net',
+      'test.pre-www.bar.net',
+    ];
+    let safeCounter = 0;
+
+    for (const safeDomain of safeDomains) {
+      if (this.isSafeDomain(safeDomain, customWhiteList)) {
+        safeCounter++;
+      }
+    }
+
+    this.body = safeCounter === 10;
+  });
+};

--- a/test/fixtures/apps/isSafeDomain-custom/config/config.js
+++ b/test/fixtures/apps/isSafeDomain-custom/config/config.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.keys = 'test key';
+
+exports.security = {
+  defaultMiddleware: 'xframe',
+  domainWhiteList: ['.domain.com', 'http://www.baidu.com', '192.*.0.*', '*.alibaba.com'],
+};

--- a/test/fixtures/apps/isSafeDomain-custom/package.json
+++ b/test/fixtures/apps/isSafeDomain-custom/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "isSafeDomain"
+}


### PR DESCRIPTION
此前，`isSafeDomain()` 只有一个参数，无法自定义白名单。

为了在 egg-cors 或其他插件中可以复用该函数的逻辑，现在增加第二个参数，
使其更加灵活。


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->