### PR TITLE
feat: CSRF cookies allow the use of signatures

### DIFF
--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -82,7 +82,7 @@ module.exports = {
    */
   get [CSRF_SECRET]() {
     if (this[_CSRF_SECRET]) return this[_CSRF_SECRET];
-    let { useSession, cookieName, sessionName } = this.app.config.security.csrf;
+    let { useSession, cookieName, sessionName, cookieOptions = {} } = this.app.config.security.csrf;
     // get secret from session or cookie
     if (useSession) {
       this[_CSRF_SECRET] = this.session[sessionName] || '';
@@ -90,7 +90,7 @@ module.exports = {
       // cookieName support array. so we can change csrf cookie name smoothly
       if (!Array.isArray(cookieName)) cookieName = [ cookieName ];
       for (const name of cookieName) {
-        this[_CSRF_SECRET] = this.cookies.get(name, { signed: false }) || '';
+        this[_CSRF_SECRET] = this.cookies.get(name, { signed: cookieOptions.signed || false }) || '';
         if (this[_CSRF_SECRET]) break;
       }
     }

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -50,6 +50,10 @@ module.exports = () => {
       refererWhiteList: [
         // 'eggjs.org'
       ],
+      // csrf token's cookie options
+      cookieOptions: {
+        signed: false,
+      },
     },
 
     xframe: {

--- a/test/csrf_cookieDomain.test.js
+++ b/test/csrf_cookieDomain.test.js
@@ -64,4 +64,24 @@ describe('test/csrf_cookieDomain.test.js', () => {
         .expect('Set-Cookie', /csrfToken=[\w\-]+; path=\/; httponly/);
     });
   });
+
+  describe('cookieOptions use signed', () => {
+    let app;
+    before(() => {
+      app = mm.app({
+        baseDir: 'apps/csrf-cookieOptions-signed',
+      });
+      return app.ready();
+    });
+    after(() => app.close());
+
+    it('should auto set csrfToken and csrfToken.sig with cookie options on GET request', () => {
+      return app.httpRequest()
+        .get('/hello')
+        .set('Host', 'abc.aaaa.ddd.string.com')
+        .expect('hello csrfToken cookieOptions signed')
+        .expect(200)
+        .expect('Set-Cookie', /csrfToken=[\w\-]+; path=\/,csrfToken\.sig=[\w\-]+; path=\//);
+    });
+  });
 });

--- a/test/fixtures/apps/csrf-cookieOptions-signed/app/controller/home.js
+++ b/test/fixtures/apps/csrf-cookieOptions-signed/app/controller/home.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = app => {
+  return class Home extends app.Controller {
+    * index() {
+      this.ctx.body = 'hello csrfToken cookieOptions signed';
+    }
+  };
+};

--- a/test/fixtures/apps/csrf-cookieOptions-signed/app/router.js
+++ b/test/fixtures/apps/csrf-cookieOptions-signed/app/router.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = app => {
+  app.get('/hello', 'home.index');
+};

--- a/test/fixtures/apps/csrf-cookieOptions-signed/config/config.default.js
+++ b/test/fixtures/apps/csrf-cookieOptions-signed/config/config.default.js
@@ -1,0 +1,11 @@
+'use strict';
+
+exports.keys = 'cookie options';
+
+exports.security = {
+  csrf: {
+    cookieOptions: {
+      signed: true
+    },
+  },
+};

--- a/test/fixtures/apps/csrf-cookieOptions-signed/package.json
+++ b/test/fixtures/apps/csrf-cookieOptions-signed/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "csrf-cookieOptions-signed"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
egg-security

##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

Double-cookie submission using signed cookies to prevent CSRF token tampering through XSS vulnerabilities on the same site but different domains, bypassing CSRF verification of their own domain.

