### PR TITLE
feat: use ip@v2

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [ master ]
-
   pull_request:
     branches: [ master ]
 
@@ -13,4 +12,6 @@ jobs:
     uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
       os: 'ubuntu-latest, macos-latest, windows-latest'
-      version: '14, 16, 18, 20'
+      version: '14, 16, 18, 20, 22'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "egg-path-matching": "^1.0.0",
     "escape-html": "^1.0.3",
     "extend": "^3.0.1",
-    "ip": "^1.1.5",
+    "ip": "^2.0.1",
     "koa-compose": "^4.1.0",
     "matcher": "^4.0.0",
     "methods": "^1.1.2",

--- a/test/safe_redirect.test.js
+++ b/test/safe_redirect.test.js
@@ -23,19 +23,19 @@ describe('test/safe_redirect.test.js', function() {
     app.httpRequest()
       .get('/safe_redirect?goto=http://domain.com')
       .expect(302)
-      .expect('location', 'http://domain.com', done);
+      .expect('location', 'http://domain.com/', done);
   });
 
   it('should redirect to / when white list is blank', async () => {
     await app2.httpRequest()
       .get('/safe_redirect?goto=http://domain.com')
       .expect(302)
-      .expect('location', 'http://domain.com');
+      .expect('location', 'http://domain.com/');
 
     await app2.httpRequest()
       .get('/safe_redirect?goto=http://baidu.com')
       .expect(302)
-      .expect('location', 'http://baidu.com');
+      .expect('location', 'http://baidu.com/');
   });
 
   it('should redirect to / when url is invaild', async () => {


### PR DESCRIPTION
ip v2 change log https://github.com/indutny/node-ip/commit/369d56d177df2e392979e353488622f0fdf2af16

closes https://github.com/eggjs/egg-security/issues/92 by the way


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to support Node.js version 22.
  - Updated `ip` package dependency to version `^2.0.1` in `package.json`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->