### PR TITLE
feat: support custom pathToRegexpModule

### DIFF
--- a/app/middleware/securities.js
+++ b/app/middleware/securities.js
@@ -13,9 +13,9 @@ module.exports = (_, app) => {
   }
 
   // format csrf.cookieDomain
-  const orginalCookieDomain = options.csrf.cookieDomain;
-  if (orginalCookieDomain && typeof orginalCookieDomain !== 'function') {
-    options.csrf.cookieDomain = () => orginalCookieDomain;
+  const originalCookieDomain = options.csrf.cookieDomain;
+  if (originalCookieDomain && typeof originalCookieDomain !== 'function') {
+    options.csrf.cookieDomain = () => originalCookieDomain;
   }
 
   defaultMiddleware.forEach(middlewareName => {
@@ -46,7 +46,10 @@ module.exports = (_, app) => {
       app.deprecate('[egg-security] Please use `config.security.xframe.ignore` instead, `config.security.xframe.blackUrls` will be removed very soon');
       opt.ignore = opt.blackUrls;
     }
-    opt.matching = createMatch(opt);
+    opt.matching = createMatch({
+      ...opt,
+      pathToRegexpModule: app.options.pathToRegexpModule,
+    });
 
     const fn = require(path.join(__dirname, '../../lib/middlewares', middlewareName))(opt, app);
     middlewares.push(fn);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@eggjs/ip": "^2.0.2",
     "csrf": "^3.0.6",
     "delegates": "^1.0.0",
-    "egg-path-matching": "^1.0.0",
+    "egg-path-matching": "^1.2.0",
     "escape-html": "^1.0.3",
     "extend": "^3.0.1",
     "koa-compose": "^4.1.0",
@@ -43,7 +43,8 @@
     "eslint": "^8.40.0",
     "eslint-config-egg": "^12.2.1",
     "spy": "^1.0.0",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "path-to-regexp-v8": "npm:path-to-regexp@8"
   },
   "scripts": {
     "lint": "eslint .",

--- a/test/fixtures/apps/iframe-with-pathToRegexpModule/app/router.js
+++ b/test/fixtures/apps/iframe-with-pathToRegexpModule/app/router.js
@@ -1,0 +1,20 @@
+module.exports = function(app) {
+  app.get('/', controller);
+  app.get('/foo', controller);
+  app.get('/hello', controller);
+  app.get('/hello/other/world', controller);
+  app.get('/world/12', controller);
+
+  app.get('/options', options, controller);
+
+  async function controller() {
+    this.body = 'body';
+  }
+
+  async function options(ctx, next) {
+    ctx.securityOptions.xframe = {
+      value: 'ALLOW-FROM http://www.domain.com',
+    };
+    return next();
+  }
+};

--- a/test/fixtures/apps/iframe-with-pathToRegexpModule/config/config.js
+++ b/test/fixtures/apps/iframe-with-pathToRegexpModule/config/config.js
@@ -1,0 +1,8 @@
+exports.keys = 'test key';
+
+exports.security = {
+  defaultMiddleware: 'xframe',
+  xframe: {
+    ignore: ['/hello', '/world/:id'],
+  },
+};

--- a/test/fixtures/apps/iframe-with-pathToRegexpModule/package.json
+++ b/test/fixtures/apps/iframe-with-pathToRegexpModule/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "iframe-with-pathToRegexpModule"
+}

--- a/test/xframe-with-pathToRegexpModule.test.js
+++ b/test/xframe-with-pathToRegexpModule.test.js
@@ -1,33 +1,37 @@
 const { strict: assert } = require('node:assert');
 const mm = require('egg-mock');
 
-describe('test/xframe.test.js', () => {
+describe('test/xframe-with-pathToRegexpModule.test.js', () => {
   let app;
   let app2;
   let app3;
   let app4;
   before(async () => {
     app = mm.app({
-      baseDir: 'apps/iframe',
+      baseDir: 'apps/iframe-with-pathToRegexpModule',
       plugin: 'security',
+      pathToRegexpModule: require.resolve('path-to-regexp-v8'),
     });
     await app.ready();
 
     app2 = mm.app({
       baseDir: 'apps/iframe-novalue',
       plugin: 'security',
+      pathToRegexpModule: require.resolve('path-to-regexp-v8'),
     });
     await app2.ready();
 
     app3 = mm.app({
       baseDir: 'apps/iframe-allowfrom',
       plugin: 'security',
+      pathToRegexpModule: require.resolve('path-to-regexp-v8'),
     });
     await app3.ready();
 
     app4 = mm.app({
       baseDir: 'apps/iframe-black-urls',
       plugin: 'security',
+      pathToRegexpModule: require.resolve('path-to-regexp-v8'),
     });
     await app4.ready();
   });
@@ -75,11 +79,12 @@ describe('test/xframe.test.js', () => {
       .expect(200);
     assert.equal(res.headers['x-frame-options'], undefined);
 
+    // '/hello' won't match '/hello/other/world' on path-to-regexp@8
     res = await app.httpRequest()
       .get('/hello/other/world')
       .set('accept', 'text/html')
       .expect(200);
-    assert.equal(res.headers['x-frame-options'], undefined);
+    assert.equal(res.headers['x-frame-options'], 'SAMEORIGIN');
 
     res = await app4.httpRequest()
       .get('/hello')


### PR DESCRIPTION
part of https://github.com/eggjs/core/pull/290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated `egg-path-matching` to version 1.2.0
	- Added `path-to-regexp-v8` dependency

- **Security Enhancements**
	- Improved X-Frame-Options middleware configuration
	- Added support for custom path matching in security middleware

- **Testing**
	- Added comprehensive test suite for X-Frame-Options header behavior
	- Introduced new test fixtures for path matching scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->